### PR TITLE
Set Billing Email in Payload

### DIFF
--- a/src/Checkout/checkout.jsx
+++ b/src/Checkout/checkout.jsx
@@ -163,7 +163,7 @@ export default class Checkout extends React.PureComponent {
             this.state.billingAddress;
 
         let { payment } = this.state;
-
+        billingAddressPayload.email = this.state.customer.email;
         this.setState({ isPlacingOrder: true });
         event.preventDefault();
 


### PR DESCRIPTION
The billing email address is missing & causing an error during checkout
This throws an error ```An error has occurred
Your billing address has missing information or is invalid. Please return to billing section of checkout and provide valid details```

![Screen Shot 2019-07-24 at 3 26 58 PM](https://user-images.githubusercontent.com/15876529/61826169-82078800-ae27-11e9-84f5-65708918f8be.png)

The email address used in the customers' state needs to be sent in the payload to avoid this error.

![Screen Shot 2019-07-24 at 3 26 49 PM](https://user-images.githubusercontent.com/15876529/61826379-ea566980-ae27-11e9-9d18-d0cbda73afd7.png)
